### PR TITLE
feat: nix build and devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.direnv
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1725409566,
+        "narHash": "sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7e4586bad4e3f8f97a9271def747cf58c4b68f3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1726900127,
+        "narHash": "sha256-v3r7yJY8YE4HAzD5DXOxLkzj8YZKQ0xuccp9yppGW1U=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "18eefba7fd0bf03e115785948758a44125a9fd68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726755586,
+        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1726443025,
+        "narHash": "sha256-nCmG4NJpwI0IoIlYlwtDwVA49yuspA2E6OhfCOmiArQ=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "94b526fc86eaa0e90fb4d54a5ba6313aa1e9b269",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "A simple and friendlier alternative to Apache Kafka";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    crane,
+    fenix,
+    ...
+  }: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ] (system:
+        function (import nixpkgs {
+          inherit system;
+          overlays = [fenix.overlays.default];
+        }));
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (pkgs: let
+      craneLib = crane.mkLib pkgs;
+
+      commonArgs = {
+        src = craneLib.cleanCargoSource ./.;
+        strictDeps = true;
+      };
+    in {
+      default = craneLib.buildPackage (commonArgs
+        // {
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        });
+    });
+
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        nativeBuildInputs = [
+          pkgs.xxd # useful for debugging
+          pkgs.rust-analyzer-nightly
+          pkgs.fenix.stable.defaultToolchain
+        ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
Works on x86_64-linux and aarch64-linux as that's all I have on-hand to test currently.

Formatter set to alejandra since that seems to be the current best thing:tm: in the ecosystem, at least until nixos/nixfmt becomes stable.

The `.envrc` is useful for people using direnv, still has to be manually allowed with a command as to not be RCEaaS. You can remove and gitignore it if you like.

`/result` is added to the ignore since by default `nix build` symlinks the `/nix/store/...` to it.